### PR TITLE
Replace apply with rowSums for better performance

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -1993,7 +1993,7 @@ AOS_profile.all <- function(mesh, par, nb=6, by.deg=1, ref="longest", plots=F, i
   di = numeric(dim(SOURCE)[1])
   for (p in 1:dim(SOURCE)[1]) {
     SOURCE.M <- matrix(SOURCE[p,],dim(TARGET)[1],2,byrow=T)         
-    di[p] <- min(sqrt(apply((SOURCE.M-TARGET)^2,1,sum)))
+    di[p] <- min(sqrt(rowSums((SOURCE.M-TARGET)^2)))
   }
   F1 = sum(di^2)
   if (infos==T) { print(paste("phi:", round(phi,4), "; theta:", round(theta,4),


### PR DESCRIPTION
Dear Dr. Wilczek,
I have recently been working with the vertical profile superposition (AOS_profile) method and found that it can be greatly accelerated if `apply` is replaced with `rowSums`. In my experiment the difference was about 60 vs. 300 seconds. I thought I just provide this change here so that you can integrate it if desired.